### PR TITLE
Update home.styl

### DIFF
--- a/client/home.styl
+++ b/client/home.styl
@@ -3,3 +3,8 @@ body
 
 #velocity-status-widget, #velocityOverlay
   position fixed
+
+@media (max-width: 979px)
+.navbar-fixed-top
+  position fixed
+


### PR DESCRIPTION
Header should not disappear when reading docs in less than 980px-wide window.
